### PR TITLE
Add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug Report
+about: Use this template to report a bug
+title: "[BRIEF BUG DESCRIPTION]"
+labels: bug, needs triage
+assignees: vcavallo
+---
+
+<!--
+Note: Please search to see if an issue already exists for the bug you encountered.
+[issues](https://github.com/operating-function/pallas/issues)
+
+Please delete comments like this one before submitting the issue,
+thanks! :)
+
+-->
+
+### Context:
+
+<!-- Is this a Sire bug? Runtime bug? Something from the standard library not working as expected? Something else? -->
+
+### Current Behavior:
+
+<!-- A concise description of what you're experiencing. -->
+
+### Expected Behavior:
+
+<!-- A concise description of what you expected to happen. -->
+
+### Steps To Reproduce:
+
+<!--
+Example: steps to reproduce the behavior:
+1. In this environment...
+1. With this config...
+1. Run '...'
+1. See error...
+-->
+
+### Environment:
+<!--
+Example:
+- OS: Ubuntu 20.04
+- Installation method: [Haskell stack OR Nix OR prebuilt binary]
+-->
+
+### Anything else:
+
+<!--
+Links? References? Anything that will give us more context about the issue that you are encountering!
+-->

--- a/ISSUE_TEMPLATE/proposed_demo.md
+++ b/ISSUE_TEMPLATE/proposed_demo.md
@@ -1,0 +1,32 @@
+---
+name: Proposed Example or Demo
+about: Use this template submit a new example or demo
+title: "[BRIEF DEMO DESCRIPTION]"
+labels: demo, needs triage
+assignees: vcavallo
+---
+
+<!--
+Please delete comments like this one before submitting the issue,
+thanks! :)
+-->
+
+### Description of Demo
+
+<!--
+What does this new demo do, generally?
+-->
+
+### Exemplified Feature
+
+<!--
+What novel aspect of Pallas does this demo exemplify?
+-->
+
+### The Demo Itself
+
+<!--
+Please provide the code for the demo. If it's a single file, you can paste it in a code block here. If it's more elaborate, feel free to link to the appropriate place in your fork of this repo.
+
+Include any instructions necessary for running the demo, even if it's just a single `pallas` command with the source file.
+-->

--- a/ISSUE_TEMPLATE/technical_question.md
+++ b/ISSUE_TEMPLATE/technical_question.md
@@ -1,0 +1,41 @@
+---
+name: Techincal Question
+about: Use this template to submit a question or request for clarification
+title: "[QUESTION TOPIC]"
+labels: question, needs triage
+assignees: vcavallo
+---
+
+<!--
+There are many novel concepts introduced by Pallas, and though we strive to provide helpful documentation and comments there will inevitably be questions and needed clarifications. Where possible, we'd like to document these answers somewhere the next person can find them - whether that's in the documentation or by clarifying source code where relevant.
+
+1. **Search the documentation**: Check the [documentation site](https://vaporware.gitbook.io/pallas) to see if your question is answered there.
+2. **Search for existing questions:** Search our issues for questions similar to the one you have.
+3. If you haven't found anything you can either ask us about it [on Telegram](https://t.me/vaporwareNetwork), or proceed with this issue!
+
+
+Please delete comments like this one before submitting the issue,
+thanks! :)
+-->
+
+### Context
+
+<!--
+What is the context of this question or clarification request?
+Some examples include:
+- Sire syntax clarification
+- "I do X task in Y other programming language, how do I do it in Sire?"
+- Clarification about which component of the system is responsible for a given task
+- The Haskell runtime
+- Other runtime implementations
+- How Pallas interacts with the host OS
+- Questions about existing examples or demos
+- Something else - a brief description is fine.
+
+-->
+
+### The Question Itself
+
+<!--
+Ask your question here or explain the thing you're finding confusing.
+-->


### PR DESCRIPTION
This PR adds three issue templates to the Org that can be shared across all repos or overwritten by particular projects as needed.